### PR TITLE
Install project dependencies and handle errors

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,12 +6,13 @@ torch>=2.0.0
 transformers>=4.30.0
 peft>=0.4.0
 accelerate>=0.20.0
-datasets>=2.12.0
-tokenizers>=0.13.0
 
 # Persian NLP
 hazm>=0.7.0
-parsbert>=0.1.0
+# Note: ParsBERT models are available via Hugging Face transformers library
+# Use: from transformers import AutoTokenizer, AutoModel
+# tokenizer = AutoTokenizer.from_pretrained("HooshvareLab/bert-base-parsbert-uncased")
+# model = AutoModel.from_pretrained("HooshvareLab/bert-base-parsbert-uncased")
 
 # Quantization (Optional)
 bitsandbytes>=0.41.0


### PR DESCRIPTION
Remove invalid `parsbert` and duplicate package requirements to resolve Vercel build failures.

The `parsbert` package was removed because it is not a standalone PyPI package; ParsBERT models are loaded directly via the Hugging Face `transformers` library. Duplicate entries for `datasets` and `tokenizers` were also removed to streamline dependencies.

---
<a href="https://cursor.com/background-agent?bcId=bc-9bc7fe6f-43c6-4d01-aa85-080f5786e0b3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9bc7fe6f-43c6-4d01-aa85-080f5786e0b3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

