### PR TITLE
Configure project for github pages deployment

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,25 +4,27 @@
   "version": "1.0.0",
   "type": "module",
   "description": "Frontend for Persian Legal AI Training System - React + TypeScript + Vite",
+  "homepage": "https://aminchedo.github.io/PersianLegalAITraining-System",
   "scripts": {
     "dev": "vite",
     "build": "vite build",
     "start": "vite preview --port 3000 --host",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",
+    "deploy": "gh-pages -d dist",
     "type-check": "tsc --noEmit",
     "test": "vitest",
     "test:ui": "vitest --ui",
     "test:coverage": "vitest --coverage"
   },
   "dependencies": {
+    "axios": "^1.4.0",
+    "clsx": "^2.0.0",
+    "lucide-react": "^0.263.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.8.0",
     "recharts": "^2.5.0",
-    "lucide-react": "^0.263.1",
-    "axios": "^1.4.0",
-    "clsx": "^2.0.0",
     "tailwind-merge": "^1.14.0"
   },
   "devDependencies": {
@@ -36,6 +38,7 @@
     "eslint": "^8.45.0",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.3",
+    "gh-pages": "^6.3.0",
     "postcss": "^8.4.24",
     "tailwindcss": "^3.3.0",
     "typescript": "^5.0.2",

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -4,6 +4,7 @@ import path from 'path'
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  base: '/PersianLegalAITraining-System/',
   plugins: [react()],
   resolve: {
     alias: {


### PR DESCRIPTION
Configure the frontend for GitHub Pages deployment by setting the base path, adding deployment scripts, and installing `gh-pages`.

---
<a href="https://cursor.com/background-agent?bcId=bc-ecdd04f0-382d-4880-a008-00606802a337">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ecdd04f0-382d-4880-a008-00606802a337">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

