### PR TITLE
Configure vercel for external backend

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,31 @@
+# Persian Legal AI System - Local Development Environment Variables
+# Copy this file to .env.local for local development
+
+# ===============================
+# LOCAL DEVELOPMENT API
+# ===============================
+# FastAPI backend running locally
+NEXT_PUBLIC_API_URL=http://localhost:8000
+
+# ===============================
+# DEVELOPMENT SETTINGS
+# ===============================
+NODE_ENV=development
+NEXT_PUBLIC_APP_NAME=Persian Legal AI System (Dev)
+NEXT_PUBLIC_APP_VERSION=2.0.0-dev
+
+# ===============================
+# LOCAL DEVELOPMENT FLAGS
+# ===============================
+NEXT_PUBLIC_ENABLE_TRAINING=true
+NEXT_PUBLIC_ENABLE_ANALYTICS=false
+NEXT_PUBLIC_ENABLE_USER_MANAGEMENT=true
+NEXT_PUBLIC_DEBUG_MODE=true
+
+# ===============================
+# INSTRUCTIONS FOR LOCAL SETUP
+# ===============================
+# 1. Copy this file to .env.local
+# 2. Start your FastAPI backend: uvicorn backend.main:app --reload --host 0.0.0.0 --port 8000
+# 3. Start the frontend: npm run dev
+# 4. Frontend will automatically proxy API calls to the local backend

--- a/VERCEL_DEPLOYMENT_GUIDE.md
+++ b/VERCEL_DEPLOYMENT_GUIDE.md
@@ -1,0 +1,157 @@
+# 🚀 Persian Legal AI System - Vercel Deployment Guide
+
+## Production-Ready Vercel Setup Complete ✅
+
+Your Persian Legal AI System frontend is now configured for production deployment on Vercel with an external FastAPI backend.
+
+## 📁 Configuration Files Updated
+
+### 1. Root `vercel.json`
+```json
+{
+  "version": 2,
+  "builds": [{ "src": "persian-legal-ai-frontend/package.json", "use": "@vercel/next" }],
+  "routes": [{ "src": "/(.*)", "dest": "/persian-legal-ai-frontend/$1" }],
+  "env": {
+    "NEXT_PUBLIC_API_URL": "https://your-backend-url.com"
+  }
+}
+```
+
+### 2. Root `next.config.js`
+- Added `NEXT_PUBLIC_API_URL` environment variable support
+- Fallback to `http://localhost:8000` for local development
+
+### 3. Frontend `next.config.js` 
+- Updated environment variable injection
+- Fixed API rewrites for development
+- Enhanced security headers
+
+### 4. Frontend `vercel.json`
+- Simplified for Vercel deployment
+- Removed unnecessary API functions (backend is external)
+
+### 5. API Configuration (`src/utils/api.ts`)
+- ✅ Properly configured to use `NEXT_PUBLIC_API_URL`
+- ✅ All API endpoints correctly formatted
+- ✅ Fallback to localhost for development
+
+## 🚀 Deployment Steps
+
+### Step 1: Deploy Your FastAPI Backend
+Deploy your FastAPI backend to one of these platforms:
+
+**Railway:**
+```bash
+railway login
+railway init
+railway add
+railway deploy
+# Get your URL: https://persian-legal-ai-backend.up.railway.app
+```
+
+**Render:**
+```bash
+# Connect GitHub repo to Render
+# Get your URL: https://persian-legal-ai-backend.onrender.com
+```
+
+**VPS/Docker:**
+```bash
+# Deploy with Docker
+docker build -t persian-legal-ai-backend .
+docker run -d -p 8000:8000 persian-legal-ai-backend
+# Get your URL: https://api.your-domain.com
+```
+
+### Step 2: Deploy Frontend to Vercel
+
+**Option A: Vercel CLI**
+```bash
+npm install -g vercel
+cd /workspace
+vercel --prod
+```
+
+**Option B: GitHub Integration**
+1. Push your code to GitHub
+2. Connect repository to Vercel
+3. Vercel will auto-deploy
+
+### Step 3: Configure Environment Variables in Vercel
+
+Go to your Vercel project dashboard → Settings → Environment Variables:
+
+```bash
+# Required Variables
+NEXT_PUBLIC_API_URL=https://your-actual-backend-url.com
+NODE_ENV=production
+
+# Optional Variables (see .env.production for full list)
+NEXT_PUBLIC_APP_NAME=Persian Legal AI System
+NEXT_PUBLIC_ENABLE_TRAINING=true
+NEXT_PUBLIC_DEFAULT_LOCALE=fa
+```
+
+## 🛠️ Local Development Workflow
+
+### Terminal 1: Start Backend
+```bash
+cd backend
+uvicorn main:app --reload --host 0.0.0.0 --port 8000
+```
+
+### Terminal 2: Start Frontend
+```bash
+cd persian-legal-ai-frontend
+cp ../.env.local.example .env.local
+npm install
+npm run dev
+```
+
+Frontend will automatically proxy API calls to `http://localhost:8000`
+
+## 🔗 Production Architecture
+
+```
+┌─────────────────┐    HTTPS     ┌──────────────────┐
+│   Vercel CDN    │─────────────▶│   Next.js App    │
+│  (Frontend)     │              │                  │
+└─────────────────┘              └──────────────────┘
+                                          │
+                                          │ API Calls
+                                          ▼
+                                 ┌──────────────────┐
+                                 │  FastAPI Backend │
+                                 │ (Railway/Render) │
+                                 └──────────────────┘
+```
+
+## ✅ Benefits of This Setup
+
+1. **🚀 Fast Frontend**: Vercel's global CDN for optimal performance
+2. **🔧 Flexible Backend**: Deploy FastAPI anywhere (Railway, Render, VPS)
+3. **💰 Cost Effective**: Vercel free tier + external backend hosting
+4. **🛡️ Secure**: No serverless limitations, proper CORS handling
+5. **📱 Scalable**: Independent scaling of frontend and backend
+
+## 🧪 Testing Your Deployment
+
+1. **Local Test**: `npm run dev` → `http://localhost:3000`
+2. **Production Test**: Visit your Vercel URL
+3. **API Test**: Check Network tab for API calls to your backend URL
+
+## 🔧 Environment Variables Reference
+
+See `.env.production` for complete list of available environment variables.
+
+## 🚨 Important Notes
+
+- Replace `https://your-backend-url.com` with your actual FastAPI backend URL
+- All `NEXT_PUBLIC_*` variables are exposed to the browser
+- Backend must have proper CORS configuration for your Vercel domain
+- Test your backend URL accessibility from Vercel's servers
+
+## 🎉 You're Ready to Deploy!
+
+Your Persian Legal AI System is now production-ready for Vercel deployment with external FastAPI backend hosting.

--- a/next.config.js
+++ b/next.config.js
@@ -9,6 +9,9 @@ const nextConfig = {
     locales: ['fa'],
     defaultLocale: 'fa',
   },
+  env: {
+    NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000'
+  },
   async headers() {
     return [
       {
@@ -29,6 +32,10 @@ const nextConfig = {
           {
             key: 'Referrer-Policy',
             value: 'strict-origin-when-cross-origin',
+          },
+          {
+            key: 'Content-Language',
+            value: 'fa',
           },
         ],
       },

--- a/persian-legal-ai-frontend/next.config.js
+++ b/persian-legal-ai-frontend/next.config.js
@@ -34,6 +34,7 @@ const nextConfig = {
 
   // Environment variables
   env: {
+    NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000',
     CUSTOM_KEY: process.env.CUSTOM_KEY,
   },
 
@@ -81,7 +82,7 @@ const nextConfig = {
       return [
         {
           source: '/api/:path*',
-          destination: `${process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000/api'}/:path*`,
+          destination: `${process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000'}/api/:path*`,
         },
       ];
     }

--- a/persian-legal-ai-frontend/src/utils/api.ts
+++ b/persian-legal-ai-frontend/src/utils/api.ts
@@ -1,7 +1,7 @@
 import axios, { AxiosResponse, AxiosError } from 'axios'
 
 // API Base Configuration
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000/api'
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000'
 
 // Create axios instance
 const apiClient = axios.create({

--- a/persian-legal-ai-frontend/vercel.json
+++ b/persian-legal-ai-frontend/vercel.json
@@ -1,15 +1,11 @@
 {
+  "version": 2,
   "framework": "nextjs",
   "buildCommand": "npm run build",
   "outputDirectory": ".next",
   "installCommand": "npm install",
   "devCommand": "npm run dev",
   "regions": ["iad1"],
-  "functions": {
-    "pages/api/**/*.ts": {
-      "runtime": "nodejs18.x"
-    }
-  },
   "headers": [
     {
       "source": "/(.*)",
@@ -23,19 +19,21 @@
           "value": "nosniff"
         },
         {
+          "key": "X-XSS-Protection",
+          "value": "1; mode=block"
+        },
+        {
+          "key": "Referrer-Policy",
+          "value": "strict-origin-when-cross-origin"
+        },
+        {
           "key": "Content-Language",
           "value": "fa"
         }
       ]
     }
   ],
-  "rewrites": [
-    {
-      "source": "/api/(.*)",
-      "destination": "/api-unavailable.html"
-    }
-  ],
   "env": {
-    "NEXT_PUBLIC_API_URL": "@next_public_api_url"
+    "NODE_ENV": "production"
   }
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,21 +1,19 @@
 {
   "version": 2,
+  "builds": [
+    {
+      "src": "persian-legal-ai-frontend/package.json",
+      "use": "@vercel/next"
+    }
+  ],
+  "routes": [
+    { "src": "/(.*)", "dest": "/persian-legal-ai-frontend/$1" }
+  ],
   "buildCommand": "cd persian-legal-ai-frontend && npm run build",
   "outputDirectory": "persian-legal-ai-frontend/.next",
   "installCommand": "cd persian-legal-ai-frontend && npm install",
   "devCommand": "cd persian-legal-ai-frontend && npm run dev",
   "framework": "nextjs",
-  "functions": {
-    "pages/api/**/*.ts": {
-      "runtime": "nodejs18.x"
-    }
-  },
-  "rewrites": [
-    {
-      "source": "/api/(.*)",
-      "destination": "/api-unavailable.html"
-    }
-  ],
   "headers": [
     {
       "source": "/(.*)",
@@ -31,20 +29,20 @@
         {
           "key": "X-XSS-Protection",
           "value": "1; mode=block"
-        }
-      ]
-    },
-    {
-      "source": "/api-unavailable.html",
-      "headers": [
+        },
         {
-          "key": "Cache-Control",
-          "value": "public, max-age=300"
+          "key": "Referrer-Policy",
+          "value": "strict-origin-when-cross-origin"
+        },
+        {
+          "key": "Content-Language",
+          "value": "fa"
         }
       ]
     }
   ],
   "env": {
-    "NODE_ENV": "production"
+    "NODE_ENV": "production",
+    "NEXT_PUBLIC_API_URL": "https://your-backend-url.com"
   }
 }


### PR DESCRIPTION
Configure the Next.js frontend for production-ready Vercel deployment with an external FastAPI backend.

This setup ensures proper handling of API calls by injecting `NEXT_PUBLIC_API_URL` at build time for production and using development-only rewrites for local proxying, preventing Vercel from attempting to deploy the FastAPI backend. It also includes creating clear environment variable templates and a comprehensive deployment guide.

---
<a href="https://cursor.com/background-agent?bcId=bc-5a5ecbab-10f6-4ef4-b5de-f5b84ec3de26">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5a5ecbab-10f6-4ef4-b5de-f5b84ec3de26">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

