### PR TITLE
Fix vercel deployment config for nextjs

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,18 +2,16 @@
   "version": 2,
   "builds": [
     {
-      "src": "persian-legal-ai-frontend/package.json",
+      "src": "package.json",
       "use": "@vercel/next"
     }
   ],
-  "routes": [
-    { "src": "/(.*)", "dest": "/persian-legal-ai-frontend/$1" }
+  "rewrites": [
+    {
+      "source": "/api/:path*",
+      "destination": "https://your-backend-url.com/:path*"
+    }
   ],
-  "buildCommand": "cd persian-legal-ai-frontend && npm run build",
-  "outputDirectory": "persian-legal-ai-frontend/.next",
-  "installCommand": "cd persian-legal-ai-frontend && npm install",
-  "devCommand": "cd persian-legal-ai-frontend && npm run dev",
-  "framework": "nextjs",
   "headers": [
     {
       "source": "/(.*)",


### PR DESCRIPTION
Refactor `vercel.json` to remove conflicting `routes` and add API `rewrites` for Vercel deployment.

The previous `vercel.json` configuration caused deployment failures due to the presence of both `routes` and `headers` properties, which is disallowed by Vercel. This PR resolves the conflict by removing the `routes` property, introducing a `rewrites` rule for API proxying, and streamlining the Next.js build configuration.

---
<a href="https://cursor.com/background-agent?bcId=bc-dce2eefb-730b-4c44-843c-45dea07b9ade">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-dce2eefb-730b-4c44-843c-45dea07b9ade">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

